### PR TITLE
Add TransportConnection to UnturnedPlayer class.

### DIFF
--- a/Rocket.Unturned/Player/UnturnedPlayer.cs
+++ b/Rocket.Unturned/Player/UnturnedPlayer.cs
@@ -1,4 +1,5 @@
 ﻿using SDG.Unturned;
+using SDG.NetTransport;
 using Steamworks;
 using System;
 using UnityEngine;
@@ -601,6 +602,14 @@ namespace Rocket.Unturned.Player
         public int CompareTo(object obj)
         {
             return Id.CompareTo(obj);
+        }
+        
+        public ITransportConnection TransportConnection() 
+        {
+            get 
+            {
+                return player.channel.owner.transportConnection;
+            }
         }
     }
 }


### PR DESCRIPTION
It's better than last RM, because when plugin developers needing ITransportConnection of player, they are should get SteamPlayer then they are should use it. But via this way, it can be more easier and more optimize.