### PR TITLE
Fix Deregister RocketAttributeCommand

### DIFF
--- a/Rocket/Rocket.Core/Commands/RocketCommandManager.cs
+++ b/Rocket/Rocket.Core/Commands/RocketCommandManager.cs
@@ -164,7 +164,7 @@ namespace Rocket.Core.Commands
 
         public void DeregisterFromAssembly(Assembly assembly)
         {
-            commands.RemoveAll(rc => rc.Command.GetType().Assembly == assembly);
+            commands.RemoveAll(rc => getCommandType(rc.Command).Assembly == assembly);
         }
 
         public double GetCooldown(IRocketPlayer player, IRocketCommand command)


### PR DESCRIPTION
Without this changes, RocketMod won't deregister all `RocketAttributeCommand`'s on unloading.