### PR TITLE
Added multi-chat support for UnturnedChat methods

### DIFF
--- a/Rocket.Unturned/Chat/UnturnedChat.cs
+++ b/Rocket.Unturned/Chat/UnturnedChat.cs
@@ -172,33 +172,19 @@ namespace Rocket.Unturned.Chat
             Say(CSteamID, message, color, false);
         }
 
-         public static List<string> wrapMessage(string text)
-         {
-             if (text.Length == 0) return new List<string>();
-             string[] words = text.Split(' ');
-             List<string> lines = new List<string>();
-             string currentLine = "";
-             int maxLength = 90;
-             foreach (var currentWord in words)
-             {
-  
-                 if ((currentLine.Length > maxLength) ||
-                     ((currentLine.Length + currentWord.Length) > maxLength))
-                 {
-                     lines.Add(currentLine);
-                     currentLine = "";
-                 }
-  
-                 if (currentLine.Length > 0)
-                     currentLine += " " + currentWord;
-                 else
-                     currentLine += currentWord;
-  
-             }
-  
-             if (currentLine.Length > 0)
-                 lines.Add(currentLine);
-                 return lines;
+        public static List<string> wrapMessage(string text)
+        {
+            List<string> result = new List<string>();
+
+            if (text.Length == 0)
+            {
+                return result;
             }
+
+            for (int i = 0; i < text.Length; i += ChatManager.MAX_MESSAGE_LENGTH)
+                result.Add(text.Substring(i, Math.Min(ChatManager.MAX_MESSAGE_LENGTH, text.Length - i)));
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
Rework of wrapMessage method. Originally RocketMod divides text into multiple messages every 90 characters, now it uses a constant from ChatManager, so now messages sent by plugins via UnturnedChat will look better.